### PR TITLE
add possibility to dump txt in the harvesting

### DIFF
--- a/Calibration/TkAlCaRecoProducers/interface/AlcaBeamSpotHarvester.h
+++ b/Calibration/TkAlCaRecoProducers/interface/AlcaBeamSpotHarvester.h
@@ -9,6 +9,7 @@
 #include "FWCore/Framework/interface/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "Calibration/TkAlCaRecoProducers/interface/AlcaBeamSpotManager.h"
+#include "RecoVertex/BeamSpotProducer/interface/BeamSpotWrite2Txt.h"
 
 // #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
@@ -37,6 +38,8 @@ class AlcaBeamSpotHarvester : public edm::EDAnalyzer {
   std::string 	      outputrecordName_;
   double      	      sigmaZValue_;
   double              sigmaZCut_;
+  bool                dumpTxt_;
+  std::string 	      outTxtFileName_;
   // Member Variables
   AlcaBeamSpotManager theAlcaBeamSpotManager_;
 

--- a/Calibration/TkAlCaRecoProducers/python/AlcaBeamSpotHarvester_cfi.py
+++ b/Calibration/TkAlCaRecoProducers/python/AlcaBeamSpotHarvester_cfi.py
@@ -7,7 +7,9 @@ alcaBeamSpotHarvester = cms.EDAnalyzer("AlcaBeamSpotHarvester",
 	BeamSpotLabel      = cms.untracked.string("alcaBeamSpot"),
 	outputRecordName   = cms.untracked.string("BeamSpotObjectsRcd"),
 	SigmaZValue        = cms.untracked.double(-1),
-	SigmaZCut        = cms.untracked.double(1) 
+	SigmaZCut        = cms.untracked.double(1), 
+	DumpTxt            = cms.untracked.bool(False),
+	TxtFileName        = cms.untracked.string("HPBSFit"),
     )
 )
 

--- a/RecoVertex/BeamSpotProducer/interface/BeamSpotWrite2Txt.h
+++ b/RecoVertex/BeamSpotProducer/interface/BeamSpotWrite2Txt.h
@@ -1,0 +1,60 @@
+#ifndef RecoVertex_BeamSpotProducer_BeamSpotWrite2Txt_h
+#define RecoVertex_BeamSpotProducer_BeamSpotWrite2Txt_h
+
+#include <fstream>
+
+#include "DataFormats/BeamSpot/interface/BeamSpot.h"
+
+namespace beamspot {
+
+  struct BeamSpotContainer {
+      reco::BeamSpot beamspot          ;
+      int            run               ;
+      char           beginTimeOfFit[32];
+      char           endTimeOfFit  [32];
+      int            beginLumiOfFit    ;
+      int            endLumiOfFit      ;
+      std::time_t    reftime[2]        ;
+  };
+  
+  void dumpBeamSpotTxt(std::string & fileName, bool append, beamspot::BeamSpotContainer bsContainer){
+    std::ofstream outFile;
+  
+    if (!append)
+      outFile.open(fileName.c_str());
+    else
+      outFile.open(fileName.c_str(), std::ios::app);
+  
+    outFile << "Runnumber "            << bsContainer.run                                                 << std::endl;
+    outFile << "BeginTimeOfFit "       << bsContainer.beginTimeOfFit << " "   << bsContainer.reftime[0]   << std::endl;
+    outFile << "EndTimeOfFit "         << bsContainer.endTimeOfFit   << " "   << bsContainer.reftime[1]   << std::endl;
+    outFile << "LumiRange "            << bsContainer.beginLumiOfFit << " - " << bsContainer.endLumiOfFit << std::endl;
+    outFile << "Type "                 << bsContainer.beamspot.type()                                     << std::endl;
+    outFile << "X0 "                   << bsContainer.beamspot.x0()                                       << std::endl;
+    outFile << "Y0 "                   << bsContainer.beamspot.y0()                                       << std::endl;
+    outFile << "Z0 "                   << bsContainer.beamspot.z0()                                       << std::endl;
+    outFile << "sigmaZ0 "              << bsContainer.beamspot.sigmaZ()                                   << std::endl;
+    outFile << "dxdz "                 << bsContainer.beamspot.dxdz()                                     << std::endl;
+    outFile << "dydz "                 << bsContainer.beamspot.dydz()                                     << std::endl;
+    outFile << "BeamWidthX "           << bsContainer.beamspot.BeamWidthX()                               << std::endl;
+    outFile << "BeamWidthY "           << bsContainer.beamspot.BeamWidthY()                               << std::endl;
+    for (int i = 0; i<6; ++i) {
+      outFile << "Cov("<<i<<",j) ";
+      for (int j=0; j<7; ++j) {
+        outFile << bsContainer.beamspot.covariance(i,j) << " ";
+      }
+        outFile << std::endl;
+      }
+    // Uncertainties on sigmaX and sigmaY are set to be equal. Legacy from a distant past
+    outFile << "Cov(6,j) 0 0 0 0 0 0 " << bsContainer.beamspot.covariance(6,6)                            << std::endl;
+    outFile << "EmittanceX "           << bsContainer.beamspot.emittanceX()                               << std::endl;
+    outFile << "EmittanceY "           << bsContainer.beamspot.emittanceY()                               << std::endl;
+    outFile << "BetaStar "             << bsContainer.beamspot.betaStar()                                 << std::endl;
+  
+    outFile.close();
+  }
+
+} // end namespace beamspot
+
+
+#endif

--- a/RecoVertex/BeamSpotProducer/src/BeamFitter.cc
+++ b/RecoVertex/BeamSpotProducer/src/BeamFitter.cc
@@ -24,6 +24,10 @@ ________________________________________________________________**/
 
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
+
+// HOOK RM
+#include "RecoVertex/BeamSpotProducer/interface/BeamSpotWrite2Txt.h"
+
 // Update the string representations of the time
 void BeamFitter::updateBTime() {
   char ts[] = "yyyy.mn.dd hh:mm:ss zzz ";
@@ -672,6 +676,20 @@ void BeamFitter::dumpTxtFile(std::string & fileName, bool append){
     }
   }//if bx results needed
   else {
+  
+    beamspot::BeamSpotContainer currentBS;
+    
+    currentBS.beamspot       = fbeamspot      ;
+    currentBS.run            = frun           ;
+    std::copy(fbeginTimeOfFit, fbeginTimeOfFit+32, currentBS.beginTimeOfFit);
+    std::copy(fendTimeOfFit  , fendTimeOfFit  +32, currentBS.endTimeOfFit  );
+    currentBS.beginLumiOfFit = fbeginLumiOfFit;
+    currentBS.endLumiOfFit   = fendLumiOfFit  ;
+    std::copy(freftime, freftime+2, currentBS.reftime);
+          
+    beamspot::dumpBeamSpotTxt(fileName, append, currentBS);
+        
+    /*
     outFile << "Runnumber " << frun << std::endl;
     outFile << "BeginTimeOfFit " << fbeginTimeOfFit << " " << freftime[0] << std::endl;
     outFile << "EndTimeOfFit " << fendTimeOfFit << " " << freftime[1] << std::endl;
@@ -708,6 +726,8 @@ void BeamFitter::dumpTxtFile(std::string & fileName, bool append){
     outFile << "EmittanceX " << fbeamspot.emittanceX() << std::endl;
     outFile << "EmittanceY " << fbeamspot.emittanceY() << std::endl;
     outFile << "BetaStar " << fbeamspot.betaStar() << std::endl;
+    //*/
+
 
     //write here Pv info for DIP only: This added only if append is false, which happen for DIP only :)
   if(!append){


### PR DESCRIPTION
We added:
- external function to dump the BS parameters in a txt file
- possibility to dump txt in the harvesting step
-- still need to fix the timestamps here
-- it will create one txt file per run (filename contains the run number) 
-- out txt file is disabled by default

This is meant to exercise of creating a txt within the harvesting step.
We need to fix the timestamps, will do it asap.

@rmanzoni