### PR TITLE
Add hgc sample gain fix cns cmssw 11 0 0 pre9

### DIFF
--- a/SLHCUpgradeSimulations/Configuration/python/aging.py
+++ b/SLHCUpgradeSimulations/Configuration/python/aging.py
@@ -61,7 +61,7 @@ def ageHF(process,turnon):
 
 def agedHGCal(process,algo=0):
     from SimCalorimetry.HGCalSimProducers.hgcalDigitizer_cfi import HGCal_setEndOfLifeNoise
-    process = HGCal_setEndOfLifeNoise(process,algo)
+    process = HGCal_setEndOfLifeNoise(process,byDose=True,byDoseAlgo=algo)
     return process
 
 # needs lumi to set proper ZS thresholds (tbd)

--- a/SLHCUpgradeSimulations/Configuration/python/aging.py
+++ b/SLHCUpgradeSimulations/Configuration/python/aging.py
@@ -59,9 +59,9 @@ def ageHF(process,turnon):
         process.es_hardcode.HFRecalibration = cms.bool(turnon)
     return process
 
-def agedHGCal(process):
+def agedHGCal(process,algo=0):
     from SimCalorimetry.HGCalSimProducers.hgcalDigitizer_cfi import HGCal_setEndOfLifeNoise
-    process = HGCal_setEndOfLifeNoise(process)
+    process = HGCal_setEndOfLifeNoise(process,algo)
     return process
 
 # needs lumi to set proper ZS thresholds (tbd)

--- a/SimCalorimetry/HGCalSimAlgos/interface/HGCalRadiationMap.h
+++ b/SimCalorimetry/HGCalSimAlgos/interface/HGCalRadiationMap.h
@@ -26,11 +26,12 @@ public:
   typedef std::map<std::pair<int, int>, DoseParameters> doseParametersMap;
 
   void setGeometry(const CaloSubdetectorGeometry *);
-  void setDoseMap(const std::string &);
+  void setDoseMap(const std::string &,const unsigned int &);
 
   double getDoseValue(const int, const int, const radiiVec &, bool logVal = false);
   double getFluenceValue(const int, const int, const radiiVec &, bool logVal = false);
-
+ 
+  const unsigned int &algo() { return algo_; }
   const HGCalGeometry *geom() { return hgcalGeom_; }
   const HGCalTopology *topo() { return hgcalTopology_; }
   const HGCalDDDConstants *ddd() { return hgcalDDD_; }
@@ -39,7 +40,8 @@ public:
 
 private:
   doseParametersMap readDosePars(const std::string &);
-
+  
+  const unsigned int algo_;
   const HGCalGeometry *hgcalGeom_;
   const HGCalTopology *hgcalTopology_;
   const HGCalDDDConstants *hgcalDDD_;

--- a/SimCalorimetry/HGCalSimAlgos/interface/HGCalRadiationMap.h
+++ b/SimCalorimetry/HGCalSimAlgos/interface/HGCalRadiationMap.h
@@ -41,7 +41,7 @@ public:
 private:
   doseParametersMap readDosePars(const std::string &);
   
-  const unsigned int algo_;
+  unsigned int algo_;
   const HGCalGeometry *hgcalGeom_;
   const HGCalTopology *hgcalTopology_;
   const HGCalDDDConstants *hgcalDDD_;

--- a/SimCalorimetry/HGCalSimAlgos/interface/HGCalSiNoiseMap.h
+++ b/SimCalorimetry/HGCalSimAlgos/interface/HGCalSiNoiseMap.h
@@ -12,7 +12,10 @@
 */
 class HGCalSiNoiseMap : public HGCalRadiationMap {
 public:
+
   enum GainRange_t { q80fC, q160fC, q320fC, AUTO };
+  enum NoiseMapAlgo_t { ALL, NOCCE, NONOISE, NOCCE_NONOISE };
+
 
   struct SiCellOpCharacteristics {
     SiCellOpCharacteristics()

--- a/SimCalorimetry/HGCalSimAlgos/interface/HGCalSiNoiseMap.h
+++ b/SimCalorimetry/HGCalSimAlgos/interface/HGCalSiNoiseMap.h
@@ -14,7 +14,7 @@ class HGCalSiNoiseMap : public HGCalRadiationMap {
 public:
 
   enum GainRange_t { q80fC, q160fC, q320fC, AUTO };
-  enum NoiseMapAlgo_t { ALL, NOCCE, NONOISE, NOCCE_NONOISE };
+  enum NoiseMapAlgoBits_t { FLUENCE, CCE, NOISE };
 
 
   struct SiCellOpCharacteristics {
@@ -43,13 +43,18 @@ public:
     cceParam_.push_back(parsThick);  //300
   }
 
+
+  /**
+     @short overrides base class method with specifics for the configuration of the algo
+  */
+  void setDoseMap(const std::string &,const unsigned int &);
+
   /**
      @short returns the charge collection efficiency and noise
      if gain range is set to auto, it will find the most appropriate gain to put the mip peak close to 10 ADC counts
   */
   SiCellOpCharacteristics getSiCellOpCharacteristics(const HGCSiliconDetId &did,
                                                      GainRange_t gain = GainRange_t::AUTO,
-                                                     bool ignoreFluence = false,
                                                      int aimMIPtoADC = 10);
 
   std::vector<double> &getMipEqfC() { return mipEqfC_; }
@@ -86,6 +91,9 @@ private:
 
   //conversions
   const double unitToMicro_ = 1e6;
+
+  //flags used to disable specific components of the Si operation parameters
+  bool ignoreFluence_, ignoreCCE_, ignoreNoise_;
 };
 
 #endif

--- a/SimCalorimetry/HGCalSimAlgos/src/HGCalRadiationMap.cc
+++ b/SimCalorimetry/HGCalSimAlgos/src/HGCalRadiationMap.cc
@@ -3,7 +3,10 @@
 #include <fstream>
 
 //
-void HGCalRadiationMap::setDoseMap(const std::string& fullpath) { doseMap_ = readDosePars(fullpath); }
+void HGCalRadiationMap::setDoseMap(const std::string& fullpath,const unsigned int &algo) { 
+  doseMap_ = readDosePars(fullpath); 
+  algo_ = algo;
+}
 
 //
 void HGCalRadiationMap::setGeometry(const CaloSubdetectorGeometry* geom) {

--- a/SimCalorimetry/HGCalSimAlgos/src/HGCalSiNoiseMap.cc
+++ b/SimCalorimetry/HGCalSimAlgos/src/HGCalSiNoiseMap.cc
@@ -82,6 +82,9 @@ HGCalSiNoiseMap::SiCellOpCharacteristics HGCalSiNoiseMap::getSiCellOpCharacteris
     siop.cce = std::max(0., siop.cce);
   }
 
+  //reset if CCE is to be ignored
+  if(algo_==NOCCE || algo_==NOCCE_NONOISE) siop.cce=1.0;
+
   //determine the gain to apply accounting for cce
   double S(siop.cce * mipEqfC_[cellThick]);
   if (gain == GainRange_t::AUTO) {
@@ -108,6 +111,9 @@ HGCalSiNoiseMap::SiCellOpCharacteristics HGCalSiNoiseMap::getSiCellOpCharacteris
   double enc_s(encsParam_[gain][0] + encsParam_[gain][1] * cellCap + encsParam_[gain][2] * pow(cellCap, 2));
   double enc_p(encpScale_ * sqrt(siop.ileak));
   siop.noise = hypot(enc_p, enc_s* encCommonNoiseSub_ )  * qe2fc_;
+  
+  //reset if NOISE is to be ignored
+  if(algo_==NONOISE || algo_==NOCCE_NONOISE) siop.noise=0.0;
 
   return siop;
 }

--- a/SimCalorimetry/HGCalSimAlgos/src/HGCalSiNoiseMap.cc
+++ b/SimCalorimetry/HGCalSimAlgos/src/HGCalSiNoiseMap.cc
@@ -1,7 +1,14 @@
 #include "SimCalorimetry/HGCalSimAlgos/interface/HGCalSiNoiseMap.h"
 
 //
-HGCalSiNoiseMap::HGCalSiNoiseMap() : encpScale_(840.), encCommonNoiseSub_(sqrt(1.25)), qe2fc_(1.60217646E-4) {
+HGCalSiNoiseMap::HGCalSiNoiseMap() : 
+  encpScale_(840.), 
+  encCommonNoiseSub_(sqrt(1.25)), 
+  qe2fc_(1.60217646E-4),
+  ignoreFluence_(false),
+  ignoreCCE_(false),
+  ignoreNoise_(false) 
+{
   encsParam_.push_back({636., 15.6, 0.0328});   // q80fC
   maxADCPerGain_.push_back(80.);                // the num of fC (charge) which corresponds to the max ADC value
   encsParam_.push_back({1045., 8.74, 0.0685});  // q160fC
@@ -38,9 +45,20 @@ HGCalSiNoiseMap::HGCalSiNoiseMap() : encpScale_(840.), encCommonNoiseSub_(sqrt(1
 }
 
 //
+void HGCalSiNoiseMap::setDoseMap(const std::string &fullpath,const unsigned int &algo){
+
+  //decode bits in the algo word
+  ignoreFluence_ = ((algo >> FLUENCE) & 0x1 );
+  ignoreCCE_     = ((algo >> CCE) & 0x1 );
+  ignoreNoise_   = ((algo >> NOISE) & 0x1 );
+
+  //call base class method
+  HGCalRadiationMap::setDoseMap(fullpath,algo);
+}
+
+//
 HGCalSiNoiseMap::SiCellOpCharacteristics HGCalSiNoiseMap::getSiCellOpCharacteristics(const HGCSiliconDetId &cellId,
                                                                                      GainRange_t gain,
-                                                                                     bool ignoreFluence,
                                                                                      int aimMIPtoADC) {
   SiCellOpCharacteristics siop;
 
@@ -55,7 +73,7 @@ HGCalSiNoiseMap::SiCellOpCharacteristics HGCalSiNoiseMap::getSiCellOpCharacteris
     return siop;
 
   //leakage current and CCE [muA]
-  if (ignoreFluence) {
+  if (ignoreFluence_) {
     siop.fluence = 0;
     siop.lnfluence = -1;
     siop.ileak = exp(ileakParam_[1]) * cellVol * unitToMicro_;
@@ -83,7 +101,7 @@ HGCalSiNoiseMap::SiCellOpCharacteristics HGCalSiNoiseMap::getSiCellOpCharacteris
   }
 
   //reset if CCE is to be ignored
-  if(algo_==NOCCE || algo_==NOCCE_NONOISE) siop.cce=1.0;
+  if(ignoreCCE_) siop.cce=1.0;
 
   //determine the gain to apply accounting for cce
   double S(siop.cce * mipEqfC_[cellThick]);
@@ -113,7 +131,7 @@ HGCalSiNoiseMap::SiCellOpCharacteristics HGCalSiNoiseMap::getSiCellOpCharacteris
   siop.noise = hypot(enc_p, enc_s* encCommonNoiseSub_ )  * qe2fc_;
   
   //reset if NOISE is to be ignored
-  if(algo_==NONOISE || algo_==NOCCE_NONOISE) siop.noise=0.0;
+  if(ignoreNoise_) siop.noise=0.0;
 
   return siop;
 }

--- a/SimCalorimetry/HGCalSimAlgos/test/HGCHEbackSignalScalerAnalyzer.cc
+++ b/SimCalorimetry/HGCalSimAlgos/test/HGCHEbackSignalScalerAnalyzer.cc
@@ -167,7 +167,7 @@ void HGCHEbackSignalScalerAnalyzer::analyze(const edm::Event& iEvent, const edm:
 
   //instantiate scaler
   HGCalSciNoiseMap scal;
-  scal.setDoseMap(doseMap_);
+  scal.setDoseMap(doseMap_,0);
   scal.setSipmMap(sipmMap_);
   scal.setGeometry(gHGCal_);
 

--- a/SimCalorimetry/HGCalSimAlgos/test/hgcsiNoiseMapTester_cfg.py
+++ b/SimCalorimetry/HGCalSimAlgos/test/hgcsiNoiseMapTester_cfg.py
@@ -21,16 +21,16 @@ process.source = cms.Source("EmptySource")
 from SimCalorimetry.HGCalSimProducers.hgcalDigitizer_cfi import HGCAL_ileakParam_toUse, HGCAL_cceParams_toUse
 process.plotter_eol = cms.EDAnalyzer("HGCSiNoiseMapAnalyzer",
                                      doseMap            = cms.string( options.doseMap ),
+                                     doseMapAlgo        = cms.uint32(0),
                                      ileakParam         = HGCAL_ileakParam_toUse,
                                      cceParams          = HGCAL_cceParams_toUse,
                                      aimMIPtoADC        = cms.int32(10),
-                                     ignoreGainSettings = cms.bool(False),
-                                     ignoreFluence      = cms.bool(False)
+                                     ignoreGainSettings = cms.bool(False)
                                  )
 
 process.plotter_eol_nogain = process.plotter_eol.clone( ignoreGainSettings = cms.bool(True) )
 
-process.plotter_start = process.plotter_eol.clone( ignoreFluence = cms.bool(True) )
+process.plotter_start = process.plotter_eol.clone( doseMapAlgo=cms.uint32(3) )
 
 
 process.TFileService = cms.Service("TFileService",

--- a/SimCalorimetry/HGCalSimProducers/python/hgcalDigitizer_cfi.py
+++ b/SimCalorimetry/HGCalSimProducers/python/hgcalDigitizer_cfi.py
@@ -43,12 +43,14 @@ HGCAL_cceParams_toUse = cms.PSet(
 
 HGCAL_noise_fC = cms.PSet(
     scaleByDose = cms.bool(False),
+    scaleByDoseAlgo = cms.uint32(0),
     doseMap = cms.string(""),
     values = cms.vdouble( [x*fC_per_ele for x in nonAgedNoises] ), #100,200,300 um
     )
 
 HGCAL_noise_heback = cms.PSet(
     scaleByDose = cms.bool(False),
+    scaleByDoseAlgo = cms.uint32(0),
     doseMap = cms.string(""), #empty dose map at begin-of-life
     noise_MIP = cms.double(1./100.)
     )
@@ -318,9 +320,10 @@ for _m in [hgceeDigitizer, hgchefrontDigitizer, hgchebackDigitizer, hfnoseDigiti
 #function to set noise to aged HGCal
 endOfLifeCCEs = [0.5, 0.5, 0.7]
 endOfLifeNoises = [2400.0,2250.0,1750.0]
-def HGCal_setEndOfLifeNoise(process,byDose=True):
+def HGCal_setEndOfLifeNoise(process,byDose=True,byDoseAlgo=0):
     process.HGCAL_noise_fC = cms.PSet(
         scaleByDose = cms.bool(byDose),
+        scaleByDoseAlgo = cms.uint32(byDoseAlgo),
         doseMap = cms.string("SimCalorimetry/HGCalSimProducers/data/doseParams_3000fb_fluka-3.5.15.9.txt"),
         values = cms.vdouble( [x*fC_per_ele for x in endOfLifeNoises] ), #100,200,300 um
         )
@@ -329,6 +332,7 @@ def HGCal_setEndOfLifeNoise(process,byDose=True):
         )
     process.HGCAL_noise_heback = cms.PSet(
         scaleByDose = cms.bool(byDose),
+        scaleByDoseAlgo = cms.uint32(byDoseAlgo),
         doseMap = cms.string("SimCalorimetry/HGCalSimProducers/data/doseParams_3000fb_fluka-3.5.15.9.txt"),
         noise_MIP = cms.double(1./5.) #uses noise map
         )
@@ -343,6 +347,7 @@ def HGCal_disableNoise(process):
     )
     process.HGCAL_noise_heback = cms.PSet(
         scaleByDose = cms.bool(False),
+        scaleByDoseAlgo = cms.uint32(0),
         doseMap = cms.string(""),
         noise_MIP = cms.double(0.) #zero noise
         )

--- a/SimCalorimetry/HGCalSimProducers/src/HGCDigitizerBase.cc
+++ b/SimCalorimetry/HGCalSimProducers/src/HGCDigitizerBase.cc
@@ -33,7 +33,7 @@ HGCDigitizerBase<DFr>::HGCDigitizerBase(const edm::ParameterSet& ps) : scaleByDo
         myCfg_.getParameter<edm::ParameterSet>("noise_fC").template getParameter<std::vector<double>>("values");
     noise_fC_ = std::vector<float>(noises.begin(), noises.end());
     scaleByDose_        = myCfg_.getParameter<edm::ParameterSet>("noise_fC").template getParameter<bool>("scaleByDose");
-    int scaleByDoseAlgo = myCfg_.getParameter<edm::ParameterSet>("noise_fC").template getParameter<int>("scaleByDoseAlgo");
+    int scaleByDoseAlgo = myCfg_.getParameter<edm::ParameterSet>("noise_fC").template getParameter<uint32_t>("scaleByDoseAlgo");
     doseMapFile_        = myCfg_.getParameter<edm::ParameterSet>("noise_fC").template getParameter<std::string>("doseMap");
     scal_.setDoseMap(doseMapFile_,scaleByDoseAlgo);
   } else {

--- a/SimCalorimetry/HGCalSimProducers/src/HGCDigitizerBase.cc
+++ b/SimCalorimetry/HGCalSimProducers/src/HGCDigitizerBase.cc
@@ -97,7 +97,7 @@ void HGCDigitizerBase<DFr>::runSimple(std::unique_ptr<HGCDigitizerBase::DColl>& 
     if (scaleByDose_) {
       HGCSiliconDetId detId(id);
       HGCalSiNoiseMap::SiCellOpCharacteristics siop =
-          scal_.getSiCellOpCharacteristics(detId, HGCalSiNoiseMap::AUTO, false, myFEelectronics_->getTargetMipValue());
+          scal_.getSiCellOpCharacteristics(detId, HGCalSiNoiseMap::AUTO, myFEelectronics_->getTargetMipValue());
       cce = siop.cce;
       noiseWidth = siop.noise;
       lsbADC = scal_.getLSBPerGain()[(HGCalSiNoiseMap::GainRange_t)siop.gain];

--- a/SimCalorimetry/HGCalSimProducers/src/HGCDigitizerBase.cc
+++ b/SimCalorimetry/HGCalSimProducers/src/HGCDigitizerBase.cc
@@ -32,9 +32,10 @@ HGCDigitizerBase<DFr>::HGCDigitizerBase(const edm::ParameterSet& ps) : scaleByDo
     const auto& noises =
         myCfg_.getParameter<edm::ParameterSet>("noise_fC").template getParameter<std::vector<double>>("values");
     noise_fC_ = std::vector<float>(noises.begin(), noises.end());
-    scaleByDose_ = myCfg_.getParameter<edm::ParameterSet>("noise_fC").template getParameter<bool>("scaleByDose");
-    doseMapFile_ = myCfg_.getParameter<edm::ParameterSet>("noise_fC").template getParameter<std::string>("doseMap");
-    scal_.setDoseMap(doseMapFile_);
+    scaleByDose_        = myCfg_.getParameter<edm::ParameterSet>("noise_fC").template getParameter<bool>("scaleByDose");
+    int scaleByDoseAlgo = myCfg_.getParameter<edm::ParameterSet>("noise_fC").template getParameter<int>("scaleByDoseAlgo");
+    doseMapFile_        = myCfg_.getParameter<edm::ParameterSet>("noise_fC").template getParameter<std::string>("doseMap");
+    scal_.setDoseMap(doseMapFile_,scaleByDoseAlgo);
   } else {
     noise_fC_.resize(1, 1.f);
   }

--- a/SimCalorimetry/HGCalSimProducers/src/HGCHEbackDigitizer.cc
+++ b/SimCalorimetry/HGCalSimProducers/src/HGCHEbackDigitizer.cc
@@ -19,7 +19,7 @@ HGCHEbackDigitizer::HGCHEbackDigitizer(const edm::ParameterSet& ps) : HGCDigitiz
   scaleBySipmArea_ = cfg.getParameter<bool>("scaleBySipmArea");
   sipmMapFile_ = cfg.getParameter<std::string>("sipmMap");
   scaleByDose_ = cfg.getParameter<edm::ParameterSet>("noise").getParameter<bool>("scaleByDose");
-  unsigned int scaleByDoseAlgo=cfg.getParameter<edm::ParameterSet>("noise").getParameter<bool>("scaleByDoseAlgo");
+  unsigned int scaleByDoseAlgo=cfg.getParameter<edm::ParameterSet>("noise").getParameter<uint32_t>("scaleByDoseAlgo");
   doseMapFile_ = cfg.getParameter<edm::ParameterSet>("noise").getParameter<std::string>("doseMap");
   noise_MIP_ = cfg.getParameter<edm::ParameterSet>("noise").getParameter<double>("noise_MIP");
   thresholdFollowsMIP_ = cfg.getParameter<bool>("thresholdFollowsMIP");

--- a/SimCalorimetry/HGCalSimProducers/src/HGCHEbackDigitizer.cc
+++ b/SimCalorimetry/HGCalSimProducers/src/HGCHEbackDigitizer.cc
@@ -19,6 +19,7 @@ HGCHEbackDigitizer::HGCHEbackDigitizer(const edm::ParameterSet& ps) : HGCDigitiz
   scaleBySipmArea_ = cfg.getParameter<bool>("scaleBySipmArea");
   sipmMapFile_ = cfg.getParameter<std::string>("sipmMap");
   scaleByDose_ = cfg.getParameter<edm::ParameterSet>("noise").getParameter<bool>("scaleByDose");
+  unsigned int scaleByDoseAlgo=cfg.getParameter<edm::ParameterSet>("noise").getParameter<bool>("scaleByDoseAlgo");
   doseMapFile_ = cfg.getParameter<edm::ParameterSet>("noise").getParameter<std::string>("doseMap");
   noise_MIP_ = cfg.getParameter<edm::ParameterSet>("noise").getParameter<double>("noise_MIP");
   thresholdFollowsMIP_ = cfg.getParameter<bool>("thresholdFollowsMIP");
@@ -29,7 +30,7 @@ HGCHEbackDigitizer::HGCHEbackDigitizer(const edm::ParameterSet& ps) : HGCDigitiz
   xTalk_ = cfg.getParameter<double>("xTalk");
   sdPixels_ = cfg.getParameter<double>("sdPixels");
 
-  scal_.setDoseMap(doseMapFile_);
+  scal_.setDoseMap(doseMapFile_,scaleByDoseAlgo);
   scal_.setSipmMap(sipmMapFile_);
 }
 


### PR DESCRIPTION
This patches the HGCalRadiationMap to have an algo word which can be used to customize the parameterizations to be used for noise, fluence etc.
For the HGCalSiRadiationMap the algo word has 3 bits. If the bit is on it should disable the corresponding component: bit1 =  disable fluence  bit2 = disable CCE  bit3 = disable noise.
A start scenario should be simulate with algo=3, noise can be disabled with algo=4, etc.

To enable different algos with cmsDriver one can do

from SLHCUpgradeSimulations.Configuration.aging import agedHGCal 
process = agedHGCal(process,algo)

by default algo=0 (full aging) 

The parameterizations obtained by switching algo seem to make sense
[start (algo=3)](https://psilva.web.cern.ch/psilva/HGCal/Electronics/Occupancies_9Oct/dosemap_output/sn_8_perlayer_start.png)
[end-of-life (algo=0)](https://psilva.web.cern.ch/psilva/HGCal/Electronics/Occupancies_9Oct/dosemap_output/sn_8_perlayer_eol.png)  

@deguio

PS good news i can now list franzoni/cmssw without problems